### PR TITLE
prevent shiny timeout

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -1,6 +1,10 @@
 library(shiny)
+library(shinyjs)
 
 shinyUI(fluidPage(
+  shinyjs::useShinyjs(),
+  tags$script(HTML('setInterval(function(){ $("#hiddenButton").click(); }, 1000*30);')),
+  tags$footer(shinyjs::hidden(actionButton(inputId = "hiddenButton", label = "hidden"))),
   
   titlePanel("Histogram"),
   

--- a/workspace.R
+++ b/workspace.R
@@ -1,4 +1,5 @@
 library(shiny)
+library(shinyjs)
 library(tercen)
 library(dplyr)
 library(tidyr)
@@ -14,6 +15,9 @@ getCtx <- function(session) {
 ############################################
 
 ui <- shinyUI(fluidPage(
+  shinyjs::useShinyjs(),
+  tags$script(HTML('setInterval(function(){ $("#hiddenButton").click(); }, 1000*30);')),
+  tags$footer(shinyjs::hidden(actionButton(inputId = "hiddenButton", label = "hidden"))),
   
   titlePanel("Histogram"),
   


### PR DESCRIPTION
I see that in many shiny apps we have added a 'trick' such that shiny does not become inactive (gray screen). So I thought it could be useful to add in the template instead. 
I am not sure how a shiny app is launched from inside Tercen, there might be a better way to set a global timeout for all apps?